### PR TITLE
[go-metro] Upgrade git in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ MAINTAINER Remi Hakim @remh
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 RUN apt-get update && apt-get install -y \
-    git \
     curl \
     procps \
     fakeroot
+
+RUN echo "deb http://http.debian.net/debian-backports squeeze-backports main" >/etc/apt/sources.list.d/squeeze-backports.list
+RUN apt-get update -qq && apt-get -t squeeze-backports install -y -qq \
+    git
 
 RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 RUN \curl -sSL https://get.rvm.io | bash -s stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,23 +8,24 @@ RUN apt-get update && apt-get install -y \
     fakeroot
 
 RUN echo "deb http://http.debian.net/debian-backports squeeze-backports main" >/etc/apt/sources.list.d/squeeze-backports.list
-RUN apt-get update -qq && apt-get -t squeeze-backports install -y -qq \
+RUN apt-get update -q && apt-get -t squeeze-backports install -y -q \
     git
 
 RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-RUN \curl -sSL https://get.rvm.io | bash -s stable
+RUN curl -sSL https://get.rvm.io | bash -s stable
 
-RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.2.2"
-RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
+RUN /bin/bash -l -c "rvm requirements && rvm install 2.2.2 && gem install bundler --no-ri --no-rdoc" && \
+    rm -rf /usr/local/rvm/src/ruby-2.2.2
 
 RUN curl -o /tmp/go1.3.3.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf /tmp/go1.3.3.linux-amd64.tar.gz && \
+    rm -f /tmp/go1.3.3.linux-amd64.tar.gz && \
     echo "PATH=$PATH:/usr/local/go/bin" | tee /etc/profile.d/go.sh
 
-RUN git config --global user.email "package@datadoghq.com"
-RUN git config --global user.name "Debian Omnibus Package"
-RUN git clone https://github.com/DataDog/dd-agent-omnibus.git
+RUN git config --global user.email "package@datadoghq.com" && \
+    git config --global user.name "Debian Omnibus Package" && \
+    git clone https://github.com/DataDog/dd-agent-omnibus.git
+
 # TODO: remove the checkout line after the merge to master
 RUN cd dd-agent-omnibus && \
     /bin/bash -l -c "bundle install --binstubs"


### PR DESCRIPTION
Some go packages (ie. those hosted in `gopkg.in`) require a newer git that can handle HTTP redirections.