### PR TITLE
Use omnibus 5.5.0 when installing gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN git clone https://github.com/DataDog/integrations-extras.git
 RUN git clone https://github.com/DataDog/integrations-core.git
 
 RUN cd dd-agent-omnibus && \
-    /bin/bash -l -c "OMNIBUS_RUBY_BRANCH='datadog-5.0.0' bundle install --binstubs"
+    /bin/bash -l -c "OMNIBUS_RUBY_BRANCH='datadog-5.5.0' bundle install --binstubs"
 
 RUN /bin/bash -l -c "echo 'deb http://apt.datadoghq.com/ stable main' > /etc/apt/sources.list.d/datadog.list"
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52


### PR DESCRIPTION
Not strictly necessary but speeds up the setup phase of agent builds (by doing this, most gems will already be installed with the correct versions in the image so agent builds won't have to install gems)

Related to https://github.com/DataDog/dd-agent-omnibus/pull/102