### PR TITLE
Setting the dd-agent-omnibus branch on the docker side

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,7 @@ RUN /bin/bash -l -c "echo 'deb http://apt.datadoghq.com/ stable main' > /etc/apt
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
 RUN apt-get update
 
+ADD checkout_omnibus_branch.sh /
+
 VOLUME ["/dd-agent-omnibus/pkg"]
-ENTRYPOINT /bin/bash -l /dd-agent-omnibus/omnibus_build.sh
+ENTRYPOINT /bin/bash -l /checkout_omnibus_branch.sh

--- a/checkout_omnibus_branch.sh
+++ b/checkout_omnibus_branch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+cd /dd-agent-omnibus
+
+# Allow to use a different dd-agent-omnibus branch
+git fetch --all
+git checkout $OMNIBUS_BRANCH
+git reset --hard origin/$OMNIBUS_BRANCH
+
+# running the entrypoint from dd-agent-omnibus
+cd /
+bash -l /dd-agent-omnibus/omnibus_build.sh


### PR DESCRIPTION
This allows us to update the omnibus_build.sh script in dd-agent-omnibus
without rebuilding the container.