### PR TITLE
[certs] Make ruby use up-to-date curl's certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN sed -i "s/libgmp-dev//g" /usr/local/rvm/scripts/functions/requirements/debia
 RUN /bin/bash -l -c "rvm requirements && rvm install 2.2.2 && gem install bundler --no-ri --no-rdoc" && \
     rm -rf /usr/local/rvm/src/ruby-2.2.2
 
+# Update certs used by ruby
+RUN curl -fsSL curl.haxx.se/ca/cacert.pem \
+         -o $(/bin/bash -l -c "ruby -ropenssl -e 'puts OpenSSL::X509::DEFAULT_CERT_FILE'")
+
 RUN curl -o /tmp/go1.3.3.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf /tmp/go1.3.3.linux-amd64.tar.gz && \
     rm -f /tmp/go1.3.3.linux-amd64.tar.gz && \


### PR DESCRIPTION
We've started to hit SSL cert validation issues for some URLs (`downloads.sourceforge.org` right now) because the default CA certs are too old.

Use the latest ones from curl instead. Same approach as the rhel image to install them.
  