### PR TITLE
Fix build and mitigate CVE-2019-3462 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -sSL https://get.rvm.io | bash -s stable
 
 RUN sed -i "s/libgmp-dev//g" /usr/local/rvm/scripts/functions/requirements/debian
 
-RUN /bin/bash -l -c "rvm requirements && rvm install 2.2.2 && gem install bundler --no-ri --no-rdoc" && \
+RUN /bin/bash -l -c "rvm requirements && rvm install 2.2.2 && gem install bundler -v 1.17.3 --no-ri --no-rdoc" && \
     rm -rf /usr/local/rvm/src/ruby-2.2.2
 
 # Update certs used by ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 # Mitigation for CVE-2019-3462
 RUN echo 'Acquire::http::AllowRedirect"false";' >> /etc/apt/apt.conf.d/20datadog
 # Ignore expired repos signature
+# Wheezy is EOL, security updates repo will not get any newer updates, or will do so
+# in arbitrary, unscheduled timeframes. At the time of this writing the repo has
+# expired making the following option necessary for apt to work.
 RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/20datadog
 
 RUN echo "deb http://archive.debian.org/debian wheezy main contrib non-free" > /etc/apt/sources.list && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM debian:wheezy
+FROM debian:wheezy-backports
 MAINTAINER Remi Hakim @remh
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# Mitigation for CVE-2019-3462
+RUN echo 'Acquire::http::AllowRedirect"false";' >> /etc/apt/apt.conf.d/20datadog
+# Ignore expired repos signature
+RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/20datadog
+
+RUN echo "deb http://archive.debian.org/debian wheezy main contrib non-free" > /etc/apt/sources.list && \
+ echo "deb http://archive.debian.org/debian wheezy-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list && \
+ echo "deb http://archive.debian.org/debian-security wheezy/updates main contrib non-free" > /etc/apt/sources.list.d/security.list
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
     fakeroot \
     git
 
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN curl -sSL https://get.rvm.io | bash -s stable
 
 RUN sed -i "s/libgmp-dev//g" /usr/local/rvm/scripts/functions/requirements/debian


### PR DESCRIPTION
- Use Wheezy archive repos
- Disable repo signature check (it's expired)
- Disable redirects in APT (CVE-2019-3462)
- Pin an older version of Bundler (Ruby 2.2 is no longer supported by current version)
- Add missing RVM GPG key 